### PR TITLE
Feat/dynamic palette size

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const defaultOptions = {
   paletteSize: 5
 }
 
-function colorPalette(input, options, callback) {
+function colorPalette (input, options, callback) {
   if (typeof options === 'string') {
     options = { type: options }
   }
@@ -27,8 +27,8 @@ function colorPalette(input, options, callback) {
   const config = Object.assign(defaultOptions, options)
 
   // SVG
-  if ((!Buffer.isBuffer(input) && input.match(patterns.svg))
-    || config.type === 'image/svg+xml') {
+  if ((!Buffer.isBuffer(input) && input.match(patterns.svg)) ||
+    config.type === 'image/svg+xml') {
     return callback(null, getSvgColors(input, { flat: true }))
   }
 
@@ -36,7 +36,7 @@ function colorPalette(input, options, callback) {
   return paletteFromBitmap(input, config, callback)
 }
 
-function paletteFromBitmap(filename, config, callback) {
+function paletteFromBitmap (filename, config, callback) {
   if (!callback) {
     callback = config.type
     config.type = null

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const defaultOptions = {
   paletteSize: 5
 }
 
-function colorPalette (input, options, callback) {
+function colorPalette(input, options, callback) {
   if (typeof options === 'string') {
     options = { type: options }
   }
@@ -27,11 +27,8 @@ function colorPalette (input, options, callback) {
   const config = Object.assign(defaultOptions, options)
 
   // SVG
-  if (!Buffer.isBuffer(input)) {
-    if (input.match(patterns.svg)) {
-      return callback(null, getSvgColors(input, { flat: true }))
-    }
-  } else if (config.type === 'image/svg+xml') {
+  if ((!Buffer.isBuffer(input) && input.match(patterns.svg))
+    || config.type === 'image/svg+xml') {
     return callback(null, getSvgColors(input, { flat: true }))
   }
 
@@ -39,7 +36,7 @@ function colorPalette (input, options, callback) {
   return paletteFromBitmap(input, config, callback)
 }
 
-function paletteFromBitmap (filename, config, callback) {
+function paletteFromBitmap(filename, config, callback) {
   if (!callback) {
     callback = config.type
     config.type = null

--- a/index.js
+++ b/index.js
@@ -16,12 +16,18 @@ const defaultOptions = {
 }
 
 function colorPalette (input, options, callback) {
-  if (typeof options === 'string') {
-    options = { type: options }
-  }
+  switch (typeof options) {
+    case 'string':
+      options = { type: options }
+      break
 
-  if (typeof options === 'function') {
-    callback = options
+    case 'number':
+      options = { paletteSize: options }
+      break
+
+    case 'function':
+      callback = options
+      break
   }
 
   const config = Object.assign(defaultOptions, options)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-image-colors",
-  "version": "2.0.0",
+  "version": "1.8.1",
   "description": "Extract colors from images. Supports GIF, JPG, PNG, and even SVG!",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -14,16 +14,29 @@ This package is intended for use in node environments. It won't work in a browse
 
 ## Usage
 
+
+### Syntax
+
+```
+getColors(input [, options [, callback]])
+```
+
+#### `input`
+
+`getColors` can take the path to an image, and will return a promise that, when resolved, can give you the colors of an image. Alternatively, you can use callbacks (see below).
+
 ```js
 const path = require('path')
 const getColors = require('get-image-colors')
+const imgPath = path.join(__dirname, 'double-rainbow.png')
 
-getColors(path.join(__dirname, 'double-rainbow.png')).then(colors => {
+getColors(imgPath).then(colors => {
   // `colors` is an array of color objects
 })
 ```
 
 You can also use a buffer as an input source.
+
 ```js
 const fs = require('fs')
 const buffer = fs.readFileSync(path.join(__dirname, 'double-rainbow.gif'))
@@ -33,6 +46,28 @@ getColors(buffer, 'image/gif').then(colors => {
   // `colors` is an array of color objects
 })
 ```
+
+#### options
+
+You may pass an object of options as the second parameter. The options are:
+
+|Name|Type|Default|Description|
+|-|-|-|-|
+|type|`string`|`undefined`|The MIME type of the image.|
+|paletteSize|`number`|`5`|The number of colors to return|
+
+```js
+const path = require('path')
+const getColors = require('get-image-colors')
+const imgPath = path.join(__dirname, 'double-rainbow.png')
+const opts = { paletteSize: 10 }
+
+getColors(imgPath, opts).then(colors => {
+  // `colors` will have 10 color objects in it
+})
+```
+
+### Return values
 
 `colors` is an array of [chroma.js](http://gka.github.io/chroma.js) color objects. chroma.js objects have methods that lets you pick the color format you want (RGB hex, HSL, etc), and give you access to powerful color manipulation features:
 

--- a/test/index.js
+++ b/test/index.js
@@ -101,4 +101,34 @@ describe('get-image-colors', function () {
       done()
     })
   })
+
+  // TODO: Should improve the testing for the `options` object
+
+  it('accepts an options object', function (done) {
+    const imgPath = path.join(__dirname, '/fixtures/thumb.jpg')
+    const options = {}
+
+    getColors(imgPath, options, function (err, palette) {
+      if (err) throw err
+
+      assert(Array.isArray(palette))
+      assert(palette.length)
+      assert(palette[0].hex().match(/^#[0-9a-f]{3,6}$/i))
+      done()
+    })
+  })
+
+  it('can return various palette sizes', function (done) {
+    const imgPath = path.join(__dirname, '/fixtures/thumb.jpg')
+    const options = { paletteSize: 10 }
+
+    getColors(imgPath, options, function (err, palette) {
+      if (err) throw err
+
+      assert(Array.isArray(palette))
+      assert(palette.length === options.paletteSize)
+      assert(palette[0].hex().match(/^#[0-9a-f]{3,6}$/i))
+      done()
+    })
+  })
 })


### PR DESCRIPTION
With this PR a user passes an object with some options as the second param, instead of just the type. The type is now one of the options, and included is an option for palette size.

The `paletteSize` option will control the number of swatches generated in the palette, the default being 5 (as it was).