### PR TITLE
Update Readme to document how to pass options object to specify the number of colors returned

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const patterns = {
   svg: /svg$/i
 }
 
-let paletteSize = 5;
+var paletteSize = 5
 
 function colorPalette (input, options, callback) {
   if (typeof options === 'function') {
@@ -60,7 +60,8 @@ function paletteFromBitmap (filename, options, callback) {
 
 module.exports = pify(colorPalette)
 
-module.exports.setPaletteSize = function(size) { 
-  if (typeof size === 'number')
-    paletteSize = size 
+module.exports.setPaletteSize = function (size) {
+  if (typeof size === 'number') {
+    paletteSize = size
+  }
 }

--- a/index.js
+++ b/index.js
@@ -10,19 +10,17 @@ const patterns = {
   svg: /svg$/i
 }
 
-var paletteSize = 5
-
 function colorPalette (input, options, callback) {
   if (typeof options === 'function') {
     callback = options
     options = {
       type: undefined,
-      count: paletteSize
+      count: 5
     }
   } else if (typeof options === 'string') {
     options = {
       type: options,
-      count: paletteSize
+      count: 5
     }
   }
 
@@ -44,7 +42,7 @@ function paletteFromBitmap (filename, options, callback) {
     callback = options
     options = {
       type: undefined,
-      count: paletteSize
+      count: 5
     }
   }
 
@@ -59,9 +57,3 @@ function paletteFromBitmap (filename, options, callback) {
 }
 
 module.exports = pify(colorPalette)
-
-module.exports.setPaletteSize = function (size) {
-  if (typeof size === 'number') {
-    paletteSize = size
-  }
-}

--- a/index.js
+++ b/index.js
@@ -10,17 +10,19 @@ const patterns = {
   svg: /svg$/i
 }
 
+let paletteSize = 5;
+
 function colorPalette (input, options, callback) {
   if (typeof options === 'function') {
     callback = options
     options = {
       type: undefined,
-      count: 5
+      count: paletteSize
     }
   } else if (typeof options === 'string') {
     options = {
       type: options,
-      count: 5
+      count: paletteSize
     }
   }
 
@@ -42,7 +44,7 @@ function paletteFromBitmap (filename, options, callback) {
     callback = options
     options = {
       type: undefined,
-      count: 5
+      count: paletteSize
     }
   }
 
@@ -57,3 +59,8 @@ function paletteFromBitmap (filename, options, callback) {
 }
 
 module.exports = pify(colorPalette)
+
+module.exports.setPaletteSize = function(size) { 
+  if (typeof size === 'number')
+    paletteSize = size 
+}

--- a/readme.md
+++ b/readme.md
@@ -53,15 +53,18 @@ getColors(filename, function (err, colors) {
 })
 ```
 
-The default number of colors returned is 5.  You can specify a different number of colors by setting the pallet size before the call to getColors:
+The default number of colors returned is 5.  You can specify a different number of colors by passing an options object into the call to getColors:
 
 ```js
 const path = require('path')
 const getColors = require('get-image-colors')
 
-getColors.setPaletteSize(10)
-getColors(path.join(__dirname, 'double-rainbow.png')).then(colors => {
-  // `colors` is an array of color objects
+const options = {
+  count: 10,
+  type: 'image/png'
+}
+getColors(path.join(__dirname, 'double-rainbow.png'), options).then(colors => {
+  // `colors` is an array of 10 color objects
 })
 ```
 


### PR DESCRIPTION
As a caller of get-image-colors, I would like to be able to specify the number of colors returned.

Although an "options" parameter exists, this is only to specify the image type, or a callback function.

This Pull Request adds basic support for changing the number of colors returned via a setPaletteSize function.  The default remains at 5.

This information is added to the Readme.

I've tested locally with the following parameters to setPaletteSize:
positive integers (applied as expected)
positive decimals (truncated value is applied)
zero (returns zero colors)
negative numbers (returns zero colors)
non-numeric (not applied, uses default 5)