### PR TITLE
Update `get-svg-colors` dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -227,7 +227,7 @@
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "brace-expansion": {
@@ -302,7 +302,7 @@
     },
     "cheerio": {
       "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
         "css-select": "~1.2.0",
@@ -491,7 +491,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -502,8 +502,8 @@
     },
     "css-what": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha1-ptdgRXM2X+dGhsPzEcVlE9iChfI="
     },
     "cwise-compiler": {
       "version": "1.1.3",
@@ -632,8 +632,8 @@
     },
     "dom-serializer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha1-HsQFnihLq+027sKUHUqXChic58A=",
       "requires": {
         "domelementtype": "^1.3.0",
         "entities": "^1.1.1"
@@ -641,20 +641,20 @@
     },
     "domelementtype": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8="
     },
     "domhandler": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
       "requires": {
         "domelementtype": "1"
       }
     },
     "domutils": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
         "dom-serializer": "0",
@@ -678,8 +678,8 @@
     },
     "entities": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1191,6 +1191,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "3.21.1",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+      "integrity": "sha1-FSodUdRFOA9wRrMEZy3VXRXJ5zY=",
+      "requires": {
+        "strnum": "^1.0.4"
+      }
+    },
     "fastq": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
@@ -1356,22 +1364,15 @@
       "dev": true
     },
     "get-svg-colors": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/get-svg-colors/-/get-svg-colors-1.5.1.tgz",
-      "integrity": "sha512-G3gXrkLrlmv2gqZvs05ap/kcGbchhNtUNaoaP6dIefRcrGPqSa17dGp5ap/2yN8Xs2Wi5mWn16Ww+nFuVU8lTw==",
+      "version": "2.0.0",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/get-svg-colors/-/get-svg-colors-2.0.0.tgz",
+      "integrity": "sha1-7cudR7bybvYDlcOkRYPdij9NA8M=",
       "requires": {
         "cheerio": "^0.22.0",
-        "chroma-js": "^1.1.1",
-        "is-svg": "^3.0.0",
+        "chroma-js": "^2.0.3",
+        "is-svg": "^4.3.1",
         "lodash.compact": "^3.0.0",
         "lodash.uniq": "^4.5.0"
-      },
-      "dependencies": {
-        "chroma-js": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-1.4.1.tgz",
-          "integrity": "sha512-jTwQiT859RTFN/vIf7s+Vl/Z2LcMrvMv3WUFmd/4u76AdlFC0NTNgqEEFPcRiHmAswPsMiQEDZLM8vX8qXpZNQ=="
-        }
       }
     },
     "getpass": {
@@ -1495,15 +1496,10 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
-    "html-comment-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
-      "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
-    },
     "htmlparser2": {
       "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
       "requires": {
         "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
@@ -1778,11 +1774,11 @@
       "dev": true
     },
     "is-svg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
-      "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
+      "version": "4.3.2",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/is-svg/-/is-svg-4.3.2.tgz",
+      "integrity": "sha1-oRnpky4a9T9r4ZadF5DWzF/ZR9M=",
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "fast-xml-parser": "^3.19.0"
       }
     },
     "is-symbol": {
@@ -1952,27 +1948,27 @@
     },
     "lodash.assignin": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
       "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
     },
     "lodash.bind": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
     },
     "lodash.compact": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.compact/-/lodash.compact-3.0.1.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.compact/-/lodash.compact-3.0.1.tgz",
       "integrity": "sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU="
     },
     "lodash.defaults": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.filter": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.filter/-/lodash.filter-4.6.0.tgz",
       "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
     },
     "lodash.flatten": {
@@ -1982,22 +1978,22 @@
     },
     "lodash.foreach": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
     "lodash.map": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.map/-/lodash.map-4.6.0.tgz",
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
     },
     "lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo="
     },
     "lodash.pick": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.range": {
@@ -2008,22 +2004,22 @@
     },
     "lodash.reduce": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
       "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
     },
     "lodash.reject": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.reject/-/lodash.reject-4.6.0.tgz",
       "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
     },
     "lodash.some": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "log-symbols": {
@@ -2271,8 +2267,8 @@
     },
     "nth-check": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
       "requires": {
         "boolbase": "~1.0.0"
       }
@@ -2872,8 +2868,8 @@
     },
     "readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3200,8 +3196,8 @@
     },
     "string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -3226,6 +3222,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha1-XE6Cn+Fa1P8NIMPbWsl7c8mwcts="
     },
     "supports-color": {
       "version": "7.1.0",
@@ -3377,7 +3378,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://artifactory.cd-tech26.de:443/artifactory/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "standard-markdown": "^6.0.0"
   },
   "dependencies": {
-    "pify": "^5.0.0",
     "chroma-js": "^2.1.0",
     "get-pixels": "^3.3.2",
     "get-rgba-palette": "^2.0.1",
-    "get-svg-colors": "^1.5.1"
+    "get-svg-colors": "^2.0.0",
+    "pify": "^5.0.0"
   },
   "standard": {
     "env": {


### PR DESCRIPTION
## Description

Update the version of `get-svg-colors` to the latest one that includes the security patch https://github.com/colorjs/get-svg-colors/pull/73

This fixes https://github.com/colorjs/get-image-colors/issues/25